### PR TITLE
properly handle subprocess call for raw -> mzml conversion

### DIFF
--- a/spectrum_io/raw/msraw.py
+++ b/spectrum_io/raw/msraw.py
@@ -28,11 +28,6 @@ class MSRaw:
         self.path = path
         self.output_path = output_path
 
-    @abstractmethod
-    def convert_raw_mzml(self, input_path, output_path):
-        """Use https://github.com/compomics/ThermoRawFileParser for conversion."""
-        raise NotImplementedError
-
     @staticmethod
     def read_mzml(
         source: Union[str, List[str]],

--- a/spectrum_io/raw/thermo_raw.py
+++ b/spectrum_io/raw/thermo_raw.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import subprocess
 from sys import platform
-from typing import Optional
+from typing import Optional, Union
 
 from .msraw import MSRaw
 
@@ -15,42 +15,49 @@ class ThermoRaw(MSRaw):
 
     @staticmethod
     def convert_raw_mzml(
-        input_path: str, output_path: Optional[str] = None, gzip: bool = False, ms_level: str = "2"
+        input_path: Union[pathlib.Path, str],
+        gzip: bool = False,
+        ms_level: str = "2",
+        output_path: Optional[Union[pathlib.Path, str]] = None,
     ) -> str:
         """
         Converts a ThermoRaw file to mzML.
 
         :param input_path: file path of the Thermo Rawfile
-        :param output_path: file path of the mzML path
         :param gzip: whether to gzip the file
         :param ms_level: level of MS
+        :param output_path: file path of the mzML path
+        :raises subprocess.CalledProcessError: if the subprocess for conversion failed
         :return: path to converted file as string
         """
+        if isinstance(input_path, str):
+            input_path = pathlib.Path(input_path)
         if output_path is None:
-            output_path = os.path.splitext(input_path)[0] + ".mzML"
+            output_path = input_path.with_suffix(".mzML")
+        if isinstance(output_path, str):
+            output_path = pathlib.Path(output_path)
 
         if os.path.isfile(output_path):
             logger.info(f"Found converted file at {output_path}, skipping conversion")
             return output_path
 
-        if gzip:
-            gzip_opt = "-g"
-        else:
-            gzip_opt = ""
+        exec_path = pathlib.Path(__file__).parent.absolute()  # get path of parent directory of this file
+        exec_path /= "/utils/ThermoRawFileParser/ThermoRawFileParser.exe"
 
+        exec_arg_list = [exec_path, f"{'-g ' if gzip else ''}--msLevel {ms_level} -i", input_path, "-b", output_path]
         if "linux" in platform:
-            mono = "mono"
-        elif "win" in platform:
-            mono = ""
+            exec_arg_list = ["mono"] + exec_arg_list
 
-        exec_path = pathlib.Path(__file__).parent.absolute()  # get path of parent directory of current file
-        exec_command = f"{mono} {exec_path}/utils/ThermoRawFileParser/ThermoRawFileParser.exe \
-                        {gzip_opt} --msLevel {ms_level} -i {input_path} -b {output_path}.tmp"
-        logger.info(f"Converting thermo rawfile to mzml with the command: {exec_command}")
-        subprocess.run(exec_command, shell=True, check=True)
+        logger.info(
+            f"Converting thermo rawfile to mzml with the command: {' '.join([str(arg) for arg in exec_arg_list])}"
+        )
 
-        # only rename the file now, so that we don't have a partially converted file if something fails
-        os.rename(f"{output_path}.tmp", output_path)
+        try:
+            subprocess.run(exec_arg_list, shell=True, check=True)
+        except subprocess.CalledProcessError:
+            if os.path.isfile(output_path):
+                os.remove(output_path)
+            raise  # reraise only after removing a corrupted file
 
         return output_path
 

--- a/spectrum_io/raw/thermo_raw.py
+++ b/spectrum_io/raw/thermo_raw.py
@@ -20,8 +20,9 @@ class ThermoRaw(MSRaw):
         ms_level: str = "2",
         output_path: Optional[Union[pathlib.Path, str]] = None,
     ) -> str:
-        """
-        Converts a ThermoRaw file to mzML.
+        """Converts a ThermoRaw file to mzML.
+
+        Use https://github.com/compomics/ThermoRawFileParser for conversion.
 
         :param input_path: file path of the Thermo Rawfile
         :param gzip: whether to gzip the file


### PR DESCRIPTION
1. intercept except, rm corrupted file and reraise in case of an error in the subprocess
2. use Path object instead of strings to support spaced paths
3. correct order of arguments <- optionals at the end

<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
