### PR TITLE
alphatims RT in minutes instead of seconds

### DIFF
--- a/spectrum_io/d/bruker.py
+++ b/spectrum_io/d/bruker.py
@@ -113,7 +113,10 @@ def read_timstof(hdf_file: Path, scan_to_precursor_map: pd.DataFrame) -> pd.Data
         raw_indices_sorted=False,
     )
     df.columns = ["FRAME", "SCAN", "PRECURSOR", "RETENTION_TIME", "INV_ION_MOBILITY", "MZ", "INTENSITIES"]
-
+    
+    #converting RETENTION TIME from seconds to minutes
+    df["RETENTION_TIME"] = df["RETENTION_TIME"].div(60)
+    
     # aggregation
     df_combined_grouped = (
         df.merge(

--- a/spectrum_io/d/bruker.py
+++ b/spectrum_io/d/bruker.py
@@ -113,10 +113,10 @@ def read_timstof(hdf_file: Path, scan_to_precursor_map: pd.DataFrame) -> pd.Data
         raw_indices_sorted=False,
     )
     df.columns = ["FRAME", "SCAN", "PRECURSOR", "RETENTION_TIME", "INV_ION_MOBILITY", "MZ", "INTENSITIES"]
-    
-    #converting RETENTION TIME from seconds to minutes
+
+    # converting RETENTION TIME from seconds to minutes
     df["RETENTION_TIME"] = df["RETENTION_TIME"].div(60)
-    
+
     # aggregation
     df_combined_grouped = (
         df.merge(


### PR DESCRIPTION
-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Retention time gets divided by 60 for alphatims in order to convert from seconds to minutes.
Fix for issue #88 

**Additional context**

![rt_comparison](https://github.com/wilhelm-lab/spectrum_io/assets/41147251/08a9625f-503a-4e70-8df3-b23f867b9cca)
