### PR TITLE
fixed reading scannr, if already an int

### DIFF
--- a/spectrum_io/search_result/sage.py
+++ b/spectrum_io/search_result/sage.py
@@ -60,7 +60,8 @@ class Sage(SearchResults):
         # removing .mzML
         df["RAW_FILE"] = df["RAW_FILE"].str.replace(r"\.mz[M|m][l|L]", "", regex=True)
         # extracting only the scan number
-        df["SCAN_NUMBER"] = [int(x.rsplit("=", 1)[-1]) for x in df["SCAN_NUMBER"]]
+        if not df["SCAN_NUMBER"].dtype == int:
+            df["SCAN_NUMBER"] = [int(x.rsplit("=", 1)[-1]) for x in df["SCAN_NUMBER"]]
         # creating a column of decoys and targets
         df["REVERSE"] = df["REVERSE"] < 0
         # removing modification to create the unmodified sequences


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] This comment contains a description of changes (with reason)
-   [x] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**
Support scannr from sage output that is already just the number without additional information.

**Technical details**

Sage reports scannr as the id field of scans in the mzML file. Many types, the id contains `controllerType=0 controllerNumber=1 scannr=<xyz>` which needs to be parsed. This creates problems when reading sage output that contains jus the scannr as an int already. A switch was implemented to check for this.

**Additional context**

